### PR TITLE
Propagate ROI edge angles

### DIFF
--- a/processing_tools/atia_processing_mamo.py
+++ b/processing_tools/atia_processing_mamo.py
@@ -42,7 +42,7 @@ class AtiaProcessingMamo(ProcessingAlgorithm):
             image_array = image_array.astype(np.uint8)
 
             # antes: image_with_rois, rois = segment_and_draw_rois(image_array)
-            image_with_rois, rois = segment_and_draw_rois(image_array, pixel_spacing_mm=pixel_spacing_mm)
+            image_with_rois, rois, angles = segment_and_draw_rois(image_array, pixel_spacing_mm=pixel_spacing_mm)
 
             # === DEBUG: dibujar ROIs (sin duplicar imports) ===
             def save_debug_rois(image, rois, out_path="images/rois_debug.png", angles=None):
@@ -69,7 +69,7 @@ class AtiaProcessingMamo(ProcessingAlgorithm):
                 cv2.imwrite(out_path, img_color)
 
             os.makedirs("images", exist_ok=True)
-            save_debug_rois(image_array, rois, out_path="images/rois_debug.png")
+            save_debug_rois(image_array, rois, out_path="images/rois_debug.png", angles=angles)
 
             # === Normalización para SNR/SDNR/NNPS ===
             x_bg, y_bg, w_bg, h_bg = rois["background_roi"]
@@ -87,7 +87,7 @@ class AtiaProcessingMamo(ProcessingAlgorithm):
                 original_image,
                 roi_horiz,
                 pixel_spacing_mm=pixel_spacing_mm,
-                angle_tilt_deg=-2.43,              # el de IAEA para el borde horizontal
+                angle_tilt_deg=angles.get("roi_vertical", 0.0),
                 super_sampling_factor=10,
                 hann_window_mm=25.0,
                 bin_pitch=0.25,
@@ -106,7 +106,7 @@ class AtiaProcessingMamo(ProcessingAlgorithm):
                 image=roi_v_rot,
                 roi_horizontal_edge=(0, 0, roi_v_rot.shape[1], roi_v_rot.shape[0]),
                 pixel_spacing_mm=pixel_spacing_mm,
-                angle_tilt_deg=(180.0 - 3.91),     # tu decisión: reutilizar horizontal con 176.09°
+                angle_tilt_deg=angles.get("roi_horizontal", 0.0) - 90.0,
                 super_sampling_factor=10,
                 hann_window_mm=25.0,
                 bin_pitch=0.25,

--- a/processing_tools/image_processing.py
+++ b/processing_tools/image_processing.py
@@ -87,7 +87,7 @@ def segment_and_draw_rois(image, pixel_spacing_mm):
     """
     attenuator_rois = detect_attenuators(image)
     if len(attenuator_rois) < 2:
-        return image, {}
+        return image, {}, {}
 
     roi_small = segment_small_roi(image, attenuator_rois)  # aluminio (el más chico)
     roi_main  = attenuator_rois[-1]                        # cobre (el más grande)
@@ -99,8 +99,9 @@ def segment_and_draw_rois(image, pixel_spacing_mm):
     )
 
     # === Re-centrado geométrico por recta del borde (mejor que gradiente) ===
-    roi_h = recenter_roi_to_edge(image, roi_h, max_shift_px=6)
-    roi_v = recenter_roi_to_edge(image, roi_v, max_shift_px=6)
+    roi_h, ang_h = recenter_roi_to_edge(image, roi_h, max_shift_px=6)
+    roi_v, ang_v = recenter_roi_to_edge(image, roi_v, max_shift_px=6)
+    angles = {"roi_horizontal": ang_h, "roi_vertical": ang_v}
     # =======================================================================
 
     roi_dict = {
@@ -116,7 +117,7 @@ def segment_and_draw_rois(image, pixel_spacing_mm):
     colors   = [(255, 0, 255), (0, 255, 255), (0, 255, 0), (0, 0, 255), (0, 255, 0)]
     drawn = draw_rois(image, all_rois, colors)
 
-    return drawn, roi_dict
+    return drawn, roi_dict, angles
 
 
 # --- Ya lo tenés, lo dejo aquí por claridad ---
@@ -166,10 +167,11 @@ def recenter_roi_to_edge(image, roi, max_shift_px=6):
     ys, xs = np.where(edges > 0)
     if xs.size < 30:
         # Sin bordes detectables: no toco el ROI
-        return roi
+        return roi, None
 
     # Ajuste de recta y = m x + b en coords locales del ROI
     m, b = np.polyfit(xs.astype(np.float64), ys.astype(np.float64), 1)
+    angle_deg = float(np.degrees(np.arctan(m)))
 
     # Distancia ortogonal (con signo) del centro del ROI a la recta
     cx, cy = w / 2.0, h / 2.0
@@ -191,5 +193,5 @@ def recenter_roi_to_edge(image, roi, max_shift_px=6):
     xx = int(np.clip(x + shift_x, 0, image.shape[1] - w))
     yy = int(np.clip(y + shift_y, 0, image.shape[0] - h))
 
-    return (xx, yy, w, h)
+    return (xx, yy, w, h), angle_deg
 


### PR DESCRIPTION
## Summary
- capture edge angles when recentering ROIs
- return ROI and angle information from ROI segmentation
- use measured angles to drive MTF calculations and debug visualizations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scipy')*
- `pip install scipy` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c75495f9708323a6dab5c97be98ff1